### PR TITLE
Adding a generic entry point at the root of the sdk

### DIFF
--- a/sdk.go
+++ b/sdk.go
@@ -1,0 +1,3 @@
+// Package sdk is the generic entry point for this Catchpoint SDK.
+//
+package sdk


### PR DESCRIPTION
To avoid the "no buildable Go source files in" when doing a go get on it.
