### PR TITLE
Renaming the package for the Alerts API to something less generic

### DIFF
--- a/alertAPI/common_functions.go
+++ b/alertAPI/common_functions.go
@@ -1,4 +1,4 @@
-package catchpoint
+package alertsAPI
 
 import (
 	"bytes"

--- a/alertAPI/helpers.go
+++ b/alertAPI/helpers.go
@@ -1,4 +1,4 @@
-package catchpoint
+package alertsAPI
 
 // This File contains all the helpers definitions by the different parsers
 // that can decode the messages received from the Catchpoint Push API.

--- a/alertAPI/xml_parser.go
+++ b/alertAPI/xml_parser.go
@@ -1,4 +1,4 @@
-package catchpoint
+package alertsAPI
 
 import (
 	"encoding/xml"

--- a/alertAPI/xml_struct.go
+++ b/alertAPI/xml_struct.go
@@ -1,4 +1,4 @@
-package catchpoint
+package alertsAPI
 
 // Author: Joseph Herlant
 //


### PR DESCRIPTION
It will be less confusing.
To be done in parallel in the https://github.com/tubemogul/catchpoint_pushapi_client_go repo.
