### PR TITLE
Remove quoting in message field because it breaks JSON while doesnt bring a lot of improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,3 @@ go:
 
 env:
   - GIMME_OS=linux GIMME_ARCH=amd64
-  - GIMME_OS=darwin GIMME_ARCH=amd64

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,3 @@ go:
 env:
   - GIMME_OS=linux GIMME_ARCH=amd64
   - GIMME_OS=darwin GIMME_ARCH=amd64
-  - GIMME_OS=windows GIMME_ARCH=amd64

--- a/alertAPI/api.go
+++ b/alertAPI/api.go
@@ -101,11 +101,11 @@ func (a *Alert) PrettyPrintMessage() (uint8, *string, *[]string, error) {
 			buffer.WriteString(fmt.Sprint(v.PageFailure.HttpStatusCode))
 		}
 
-		buffer.WriteString(" failed from \"")
+		buffer.WriteString(" failed from ")
 		buffer.WriteString(v.Name)
-		buffer.WriteString("\" (")
+		buffer.WriteString(" - ")
 		buffer.WriteString(v.IpAddress)
-		buffer.WriteString(") to ")
+		buffer.WriteString(" to ")
 		buffer.WriteString(v.RemoteIpAddress)
 		buffer.WriteString(" at ")
 		buffer.WriteString(a.Timestamp.ProcessingUtc)


### PR DESCRIPTION
If I use JSON output I need to sanitize message field.

I think it would be better if SDK sent a JSON friendly string from the beginning. 